### PR TITLE
fix(notify): authenticate cross-site App WebSocket via subprotocol bearer

### DIFF
--- a/packages/libs/js-lib/src/core/WebsocketData/WebsocketProvider.test.ts
+++ b/packages/libs/js-lib/src/core/WebsocketData/WebsocketProvider.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiType, DotYouClient } from '../DotYouClient';
+import type { TargetDrive } from '../core';
+
+// WebsocketProvider keeps module-level singleton state (the live socket, the subscriber
+// list). Re-import it fresh per test so one connection attempt can't leak into the next.
+const loadProvider = async () => {
+  vi.resetModules();
+  return import('./WebsocketProvider');
+};
+
+// Capture every `new WebSocket(url, protocols, args)` the provider makes, without opening a
+// real socket. Construction is synchronous inside ConnectSocket, so the capture is populated
+// by the time Subscribe() returns.
+let captured: { url: string; protocols?: string[] | string; args: unknown }[];
+
+class FakeWebSocket {
+  onopen: (() => void) | null = null;
+  onmessage: ((e: unknown) => void) | null = null;
+  onerror: ((e: unknown) => void) | null = null;
+  onclose: ((e: unknown) => void) | null = null;
+  constructor(url: string, protocols?: string[] | string, args?: unknown) {
+    captured.push({ url, protocols, args });
+  }
+  close() {}
+  send() {}
+}
+
+const makeClient = (api: ApiType, headers?: Record<string, string>) =>
+  ({
+    getType: () => api,
+    getSharedSecret: () => new Uint8Array(16).fill(1),
+    getRoot: () => 'https://example.com',
+    getHeaders: () => headers ?? {},
+  }) as unknown as DotYouClient;
+
+const drives: TargetDrive[] = [];
+
+beforeEach(() => {
+  captured = [];
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('WebsocketProvider App subprotocol auth', () => {
+  it('sends the app token as an "odin.bearer." subprotocol (base64url) for App connections', async () => {
+    const { Subscribe } = await loadProvider();
+
+    // A real bx0900 is standard base64; the "+/=" chars must become URL-safe "-_<no pad>"
+    // because Sec-WebSocket-Protocol values are RFC 7230 tokens.
+    Subscribe(makeClient(ApiType.App, { bx0900: 'ab+/cd==' }), drives, () => {}).catch(() => {});
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).toBe('wss://example.com/api/apps/v1/notify/ws');
+    expect(captured[0].protocols).toEqual(['odin.notify.v1', 'odin.bearer.ab-_cd']);
+  });
+
+  it('omits the subprotocol when the App has no bx0900 token', async () => {
+    const { Subscribe } = await loadProvider();
+
+    Subscribe(makeClient(ApiType.App, {}), drives, () => {}).catch(() => {});
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].protocols).toBeUndefined();
+  });
+
+  it('uses the same-site cookie path (no subprotocol) for Owner connections', async () => {
+    const { Subscribe } = await loadProvider();
+
+    Subscribe(makeClient(ApiType.Owner, { bx0900: 'ab+/cd==' }), drives, () => {}).catch(() => {});
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).toBe('wss://example.com/api/owner/v1/notify/ws');
+    expect(captured[0].protocols).toBeUndefined();
+  });
+});

--- a/packages/libs/js-lib/src/core/WebsocketData/WebsocketProvider.ts
+++ b/packages/libs/js-lib/src/core/WebsocketData/WebsocketProvider.ts
@@ -65,26 +65,26 @@ const ConnectSocket = async (
       return;
     }
 
-    if (apiType === ApiType.App) {
-      // we need to preauth before we can connect
-      await dotYouClient
-        .createAxiosClient()
-        .post('/notify/preauth', undefined, {
-          validateStatus: () => true,
-        })
-        .catch(() => {
-          reconnectPromise = undefined;
-          reject('[WebsocketProvider] Preauth failed');
-        });
-    }
-
     const url = `wss://${dotYouClient.getRoot().split('//')[1]}/api/${
       apiType === ApiType.Owner ? 'owner' : 'apps'
     }/v1/notify/ws`;
 
+    // App: a browser can send neither the BX0900 header nor the cross-site SameSite cookie on a
+    // WS upgrade, so carry the app token in a Sec-WebSocket-Protocol value ("odin.bearer." +
+    // base64url) — the kube-style subprotocol bearer the server accepts. No preauth cookie
+    // round-trip needed. (Owner is same-site and keeps the cookie path.)
+    let protocols: string[] | undefined;
+    if (apiType === ApiType.App) {
+      const token = dotYouClient.getHeaders()['bx0900'];
+      if (token) {
+        const tokenBase64Url = token.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+        protocols = ['odin.notify.v1', `odin.bearer.${tokenBase64Url}`];
+      }
+    }
+
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    webSocketClient = args? new WebSocket(url, undefined, args) : new WebSocket(url);
+    // @ts-ignore — 3rd arg (React-Native connection options) is ignored by browsers
+    webSocketClient = new WebSocket(url, protocols, args);
     if (isDebug) console.debug(`[WebsocketProvider] WebSocket object created, attempting connection`);
     reconnectPromise = undefined;
     isHandshaked = false;


### PR DESCRIPTION
## Problem

The App notify WebSocket authenticated via a preauth POST that set the `BX0900` cookie. When the app is served cross-site to the identity (e.g. journal on `journal.cloudx.run`), that cookie is `SameSite=Strict` and is never sent on the WS upgrade, so the socket 401s and the client reconnect-loops.

## Fix

For App connections, carry the app token in a `Sec-WebSocket-Protocol` value — the only channel a browser can set on a WS handshake — as `odin.bearer.<base64url>`, and drop the now-pointless preauth round-trip. This is the kube-style subprotocol bearer the server accepts.

```ts
protocols = ['odin.notify.v1', `odin.bearer.${tokenBase64Url}`];
new WebSocket(url, protocols, args);
```

The `BX0900` token (standard base64) is made URL-safe (`+`→`-`, `/`→`_`, strip `=`) so it is a valid RFC 7230 subprotocol token; the server reverses the swap and parses it. Owner connections are same-site and keep the cookie path unchanged. React Native is preserved — the token goes in the standard 2nd arg and the RN options still flow as the 3rd.

### Test

`WebsocketProvider.test.ts` (new) stubs `WebSocket` and asserts:
- App → `['odin.notify.v1', 'odin.bearer.<base64url>']` with the base64→base64url char-swap applied;
- App with no token → no subprotocol;
- Owner → no subprotocol, `/api/owner/...` URL (cookie path).

## Paired change

Requires the matching server change in **homebase-id/odin-core#1580** (V1 notify handler accepts the `odin.bearer.` subprotocol and echoes `odin.notify.v1`). Neither half is useful without the other deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
