### PR TITLE
fix(notify): opt-in V2 subprotocol auth for cross-site App WebSocket

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21939,7 +21939,7 @@
     },
     "packages/libs/js-lib": {
       "name": "@homebase-id/js-lib",
-      "version": "0.0.7-alpha.81",
+      "version": "0.0.7-alpha.82",
       "dependencies": {
         "guid-typescript": "^1.0.9"
       },

--- a/packages/libs/js-lib/package.json
+++ b/packages/libs/js-lib/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.7-alpha.81",
+  "version": "0.0.7-alpha.82",
   "name": "@homebase-id/js-lib",
   "author": "YouFoundation",
   "description": "Monorepo that contains all the main homebase apps, together with the JavaScript libraries",

--- a/packages/libs/js-lib/src/core/WebsocketData/WebsocketProvider.test.ts
+++ b/packages/libs/js-lib/src/core/WebsocketData/WebsocketProvider.test.ts
@@ -2,16 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiType, DotYouClient } from '../DotYouClient';
 import type { TargetDrive } from '../core';
 
-// WebsocketProvider keeps module-level singleton state (the live socket, the subscriber
-// list). Re-import it fresh per test so one connection attempt can't leak into the next.
 const loadProvider = async () => {
   vi.resetModules();
   return import('./WebsocketProvider');
 };
 
-// Capture every `new WebSocket(url, protocols, args)` the provider makes, without opening a
-// real socket. Construction is synchronous inside ConnectSocket, so the capture is populated
-// by the time Subscribe() returns.
+// Let the connect promise executor run past its preauth `await` so the V1 path
+// reaches `new WebSocket`. The V2 path has no await before construction.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
 let captured: { url: string; protocols?: string[] | string; args: unknown }[];
 
 class FakeWebSocket {
@@ -32,6 +31,7 @@ const makeClient = (api: ApiType, headers?: Record<string, string>) =>
     getSharedSecret: () => new Uint8Array(16).fill(1),
     getRoot: () => 'https://example.com',
     getHeaders: () => headers ?? {},
+    createAxiosClient: () => ({ post: () => Promise.resolve() }),
   }) as unknown as DotYouClient;
 
 const drives: TargetDrive[] = [];
@@ -45,33 +45,38 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('WebsocketProvider App subprotocol auth', () => {
-  it('sends the app token as an "odin.bearer." subprotocol (base64url) for App connections', async () => {
+describe('WebsocketProvider V1/V2 selection', () => {
+  it('defaults to the V1 cookie path (no subprotocol) for App connections', async () => {
     const { Subscribe } = await loadProvider();
-
-    // A real bx0900 is standard base64; the "+/=" chars must become URL-safe "-_<no pad>"
-    // because Sec-WebSocket-Protocol values are RFC 7230 tokens.
-    Subscribe(makeClient(ApiType.App, { bx0900: 'ab+/cd==' }), drives, () => {}).catch(() => {});
-
+    Subscribe(makeClient(ApiType.App, { bx0900: 'ab+/cd==' }), drives, () => {}, undefined, undefined, undefined, undefined, false).catch(() => {});
+    await flush();
     expect(captured).toHaveLength(1);
     expect(captured[0].url).toBe('wss://example.com/api/apps/v1/notify/ws');
-    expect(captured[0].protocols).toEqual(['odin.notify.v1', 'odin.bearer.ab-_cd']);
-  });
-
-  it('omits the subprotocol when the App has no bx0900 token', async () => {
-    const { Subscribe } = await loadProvider();
-
-    Subscribe(makeClient(ApiType.App, {}), drives, () => {}).catch(() => {});
-
-    expect(captured).toHaveLength(1);
     expect(captured[0].protocols).toBeUndefined();
   });
 
-  it('uses the same-site cookie path (no subprotocol) for Owner connections', async () => {
+  it('uses the V2 route with the "odin.bearer." subprotocol (base64url) when useV2 is set', async () => {
     const { Subscribe } = await loadProvider();
+    Subscribe(makeClient(ApiType.App, { bx0900: 'ab+/cd==' }), drives, () => {}, undefined, undefined, undefined, undefined, true).catch(() => {});
+    await flush();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).toBe('wss://example.com/api/v2/notify/ws-token-wasm');
+    expect(captured[0].protocols).toEqual(['odin.notify.v1', 'odin.bearer.ab-_cd']);
+  });
 
-    Subscribe(makeClient(ApiType.Owner, { bx0900: 'ab+/cd==' }), drives, () => {}).catch(() => {});
+  it('omits the subprotocol on V2 when the App has no bx0900 token', async () => {
+    const { Subscribe } = await loadProvider();
+    Subscribe(makeClient(ApiType.App, {}), drives, () => {}, undefined, undefined, undefined, undefined, true).catch(() => {});
+    await flush();
+    expect(captured).toHaveLength(1);
+    expect(captured[0].url).toBe('wss://example.com/api/v2/notify/ws-token-wasm');
+    expect(captured[0].protocols).toBeUndefined();
+  });
 
+  it('ignores useV2 for Owner connections (stays on V1 cookie path)', async () => {
+    const { Subscribe } = await loadProvider();
+    Subscribe(makeClient(ApiType.Owner, { bx0900: 'ab+/cd==' }), drives, () => {}, undefined, undefined, undefined, undefined, true).catch(() => {});
+    await flush();
     expect(captured).toHaveLength(1);
     expect(captured[0].url).toBe('wss://example.com/api/owner/v1/notify/ws');
     expect(captured[0].protocols).toBeUndefined();

--- a/packages/libs/js-lib/src/core/WebsocketData/WebsocketProvider.ts
+++ b/packages/libs/js-lib/src/core/WebsocketData/WebsocketProvider.ts
@@ -43,14 +43,29 @@ const subscribers: {
 
 const isDebug = hasDebugFlag();
 
+// V2 (App only) authenticates the WS upgrade with a Sec-WebSocket-Protocol bearer instead of the
+// preauth cookie, so a browser can connect cross-site where it can send neither the BX0900 header
+// nor the SameSite cookie on the upgrade. 'odin.notify.v1' is echoed by the server so the browser
+// accepts the 101. Mirrors the kube-apiserver subprotocol-bearer pattern.
+const getV2Protocols = (dotYouClient: DotYouClient): string[] | undefined => {
+  const token = dotYouClient.getHeaders()['bx0900'];
+  if (!token) return undefined;
+  // Subprotocol values must be RFC 7230 tokens, so the base64 token is sent base64url-encoded.
+  const base64Url = token.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return ['odin.notify.v1', `odin.bearer.${base64Url}`];
+};
+
 const ConnectSocket = async (
   dotYouClient: DotYouClient,
   drives: TargetDrive[],
-  args?: unknown // Extra parameters to pass to WebSocket constructor; Only applicable for React Native...;
+  args?: unknown, // Extra parameters to pass to WebSocket constructor; Only applicable for React Native...;
+  useV2 = false
 ) => {
   if (webSocketClient) throw new Error('Socket already connected');
 
   const apiType = dotYouClient.getType();
+  // V2 is App-only; Owner always stays on the V1 cookie path.
+  const useV2App = useV2 && apiType === ApiType.App;
 
   // We're already connecting, return the existing promise
   if (connectPromise) return connectPromise;
@@ -65,26 +80,29 @@ const ConnectSocket = async (
       return;
     }
 
-    const url = `wss://${dotYouClient.getRoot().split('//')[1]}/api/${
-      apiType === ApiType.Owner ? 'owner' : 'apps'
-    }/v1/notify/ws`;
-
-    // App: a browser can send neither the BX0900 header nor the cross-site SameSite cookie on a
-    // WS upgrade, so carry the app token in a Sec-WebSocket-Protocol value ("odin.bearer." +
-    // base64url) — the kube-style subprotocol bearer the server accepts. No preauth cookie
-    // round-trip needed. (Owner is same-site and keeps the cookie path.)
-    let protocols: string[] | undefined;
-    if (apiType === ApiType.App) {
-      const token = dotYouClient.getHeaders()['bx0900'];
-      if (token) {
-        const tokenBase64Url = token.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-        protocols = ['odin.notify.v1', `odin.bearer.${tokenBase64Url}`];
-      }
+    if (apiType === ApiType.App && !useV2App) {
+      // we need to preauth before we can connect
+      await dotYouClient
+        .createAxiosClient()
+        .post('/notify/preauth', undefined, {
+          validateStatus: () => true,
+        })
+        .catch(() => {
+          reconnectPromise = undefined;
+          reject('[WebsocketProvider] Preauth failed');
+        });
     }
 
+    const host = dotYouClient.getRoot().split('//')[1];
+    const url = useV2App
+      ? `wss://${host}/api/v2/notify/ws-token-wasm`
+      : `wss://${host}/api/${apiType === ApiType.Owner ? 'owner' : 'apps'}/v1/notify/ws`;
+
+    const protocols = useV2App ? getV2Protocols(dotYouClient) : undefined;
+
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore — 3rd arg (React-Native connection options) is ignored by browsers
-    webSocketClient = new WebSocket(url, protocols, args);
+    // @ts-ignore
+    webSocketClient = protocols ? new WebSocket(url, protocols, args) : args ? new WebSocket(url, undefined, args) : new WebSocket(url);
     if (isDebug) console.debug(`[WebsocketProvider] WebSocket object created, attempting connection`);
     reconnectPromise = undefined;
     isHandshaked = false;
@@ -114,7 +132,7 @@ const ConnectSocket = async (
 
           // 2 ping intervals have passed without a pong, reconnect
           if (isDebug) console.debug(`[WebsocketProvider] Ping timeout`);
-          ReconnectSocket(dotYouClient, drives, args);
+          ReconnectSocket(dotYouClient, drives, args, useV2);
           return;
         }
         Notify({
@@ -164,7 +182,7 @@ const ConnectSocket = async (
         }
       }
 
-      ReconnectSocket(dotYouClient, drives, args);
+      ReconnectSocket(dotYouClient, drives, args, useV2);
     };
   });
 
@@ -174,7 +192,8 @@ const ConnectSocket = async (
 const ReconnectSocket = async (
   dotYouClient: DotYouClient,
   drives: TargetDrive[],
-  args?: unknown // Extra parameters to pass to WebSocket constructor; Only applicable for React Native...; TODO: Remove this
+  args?: unknown, // Extra parameters to pass to WebSocket constructor; Only applicable for React Native...; TODO: Remove this
+  useV2 = false
 ) => {
   if (reconnectPromise) return;
 
@@ -201,7 +220,7 @@ const ReconnectSocket = async (
       if (isDebug) console.debug(`[WebsocketProvider] Reconnecting - Delayed reconnect #${reconnectCounter} at ${Date.now()}ms`);
 
       try {
-        await ConnectSocket(dotYouClient, drives, args);
+        await ConnectSocket(dotYouClient, drives, args, useV2);
       } catch (e) {
         console.error('[WebsocketProvider] Reconnect failed', e);
         reject();
@@ -241,7 +260,8 @@ export const Subscribe = async (
   onDisconnect?: () => void,
   onReconnect?: () => void,
   args?: unknown, // Extra parameters to pass to WebSocket constructor; Only applicable for React Native...; TODO: Remove this,
-  refId?: string
+  refId?: string,
+  useV2 = false // App only: authenticate the upgrade with the odin.bearer subprotocol against /api/v2 (cross-site capable)
 ): Promise<void> => {
   const apiType = dotYouClient.getType();
   const sharedSecret = dotYouClient.getSharedSecret();
@@ -270,7 +290,7 @@ export const Subscribe = async (
 
   // Already connected, no need to initiate a new connection
   if (webSocketClient) return Promise.resolve();
-  return ConnectSocket(dotYouClient, drives, args);
+  return ConnectSocket(dotYouClient, drives, args, useV2);
 };
 
 export const Unsubscribe = (


### PR DESCRIPTION
## What

Adds an opt-in `useV2` flag to `Subscribe` so an App WebSocket can authenticate the upgrade with a `Sec-WebSocket-Protocol` bearer (`odin.bearer.<base64url(token)>`) against the existing **V2** route `/api/v2/notify/ws-token-wasm`, instead of the V1 preauth cookie.

Browsers can send neither the `BX0900` header nor the `SameSite` app cookie on a **cross-site** WS upgrade, so the V1 cookie path can't connect cross-site (e.g. the journal app on a different registrable domain than the identity). The V2 controller already accepts this subprotocol bearer and resolves the **same** App token via the same `GetAppPermissionContextAsync`, so **no backend change is required**.

## Why this supersedes #872

The merged #872 took the *in-place* route: it made the **V1** path carry the subprotocol and dropped preauth, which only works once the matching backend handler change (odin-core **#1580**) ships. #1580 was never merged, so `main`'s App WS is currently incomplete. This PR:

- **Reverts** the in-place V1 change — restores the original preauth-cookie default (no behaviour change for existing consumers, no backend dependency).
- **Adds** `useV2` (default `false`). App + `useV2` → V2 route + `odin.bearer.` subprotocol. Owner always stays on V1.

odin-core #1580 can be closed.

## Tests

`WebsocketProvider.test.ts` (4): V1 default (no subprotocol, V1 URL), V2 opt-in (V2 URL + `['odin.notify.v1','odin.bearer.…']`), V2 with no token (no subprotocol), Owner ignores the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)