### PR TITLE
fix(provisioning): reframe managed-domain field as "Choose your username" (#1029)

### DIFF
--- a/packages/apps/provisioning-app/src/components/ManagedDomain/EnteringDetails.tsx
+++ b/packages/apps/provisioning-app/src/components/ManagedDomain/EnteringDetails.tsx
@@ -52,6 +52,14 @@ const EnteringDetails = ({
     }
   }, [domainPrefix, domainApex]);
 
+  // Live preview of the resulting address; falls back to the placeholder labels
+  // so it always reads like a real address (e.g. john.doe.id.pub) before typing.
+  const previewDomain = useMemo(() => {
+    if (!domainApex) return '';
+    const parts = domainApex.prefixLabels.map((label, i) => prefixes[i]?.trim() || label);
+    return domainFromPrefixAndApex(parts.join('.'), domainApex.apex);
+  }, [prefixes, domainApex]);
+
   //
   // API
   //
@@ -121,7 +129,7 @@ const EnteringDetails = ({
           className="w-full max-w-5xl"
         >
           <div className="flex flex-row flex-wrap items-center">
-            <Label>{t('Your domain')}</Label>
+            <Label>{t('Choose your username')}</Label>
             {isManagedDomainAvailable === false && domain ? (
               <p
                 className="order-1 ml-auto mt-2 flex flex-row items-center rounded-lg bg-slate-100 px-2 py-1 md:order-none md:mt-0 md:rounded-b-none">
@@ -130,6 +138,12 @@ const EnteringDetails = ({
               </p>
             ) : null}
           </div>
+          <small className="mb-1 block text-sm font-normal text-slate-500">
+            <span className="font-medium">https://{previewDomain}/</span>{' '}
+            {t(
+              'also doubles as your own public-facing website. You can choose between other options in the drop-down.'
+            )}
+          </small>
           <div className="flex w-full flex-col flex-wrap gap-2 md:flex-row">
             {domainApex.prefixLabels.map((label, index) => (
               <div className="flex-grow" key={index}>


### PR DESCRIPTION
Fixes homebase-id/chat-kmp#1029 (filed there for tracking; the fix lives in this provisioning frontend).

## Problem
On the managed-domain signup step (`ManagedDomain/EnteringDetails.tsx`), the **"Your domain"** label reads like it wants an existing domain the user already owns — so first-time users stall. The field is really "pick a username" that becomes `username.<apex>.id.pub`.

## Change
- **Relabel** "Your domain" → **"Choose your username"**.
- **Add a helper line** below the label (mirrors the existing "Your email" grey `<small>` helper style) that:
  - shows a **live preview** of the resulting address — `https://john.doe.id.pub/` — tracking the typed name fields + selected apex, falling back to the placeholder labels before typing so it always reads like a real address;
  - explains the address **doubles as a public-facing website**;
  - points at the **apex drop-down** ("choose between other options in the drop-down").

The drop-down contents and the registration backend are untouched.

## Verification
- `tsc --noEmit` — exit 0; `eslint` on the file — exit 0.
- Live visual check of this step needs the provisioning backend (the view renders a loader until the managed-domain apexes API responds), so it wasn't captured here; the change is a copy/label swap plus a `<small>` that reuses the already-rendered email-helper pattern.

## Acceptance criteria
- [x] "Your domain" replaced with a username-framed label.
- [x] Helper line explains the address is both identity and a public website, and mentions the drop-down.
- [x] Live `username.apex.id.pub` preview tracks the two name fields + selected apex.
- [ ] First-time-user check — recommend a quick manual pass on staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)